### PR TITLE
Receipt writing

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -80,7 +80,7 @@ type ExecutionResponse interface {
 }
 
 func Execute(invocations []invocation.Invocation, conn Connection) (ExecutionResponse, error) {
-	input, err := message.Build(invocations)
+	input, err := message.Build(invocations, nil)
 	if err != nil {
 		return nil, fmt.Errorf("building message: %s", err)
 	}

--- a/core/dag/blockstore/blockstore.go
+++ b/core/dag/blockstore/blockstore.go
@@ -194,3 +194,21 @@ func NewBlockReader(options ...Option) (BlockReader, error) {
 
 	return &blockreader{keys, blks}, nil
 }
+
+func Encode(view ipld.View, bs BlockWriter) error {
+	blks := view.Blocks()
+	for {
+		b, err := blks.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return fmt.Errorf("reading proof blocks: %s", err)
+		}
+		err = bs.Put(b)
+		if err != nil {
+			return fmt.Errorf("putting proof block: %s", err)
+		}
+	}
+	return nil
+}

--- a/core/delegation/delegate.go
+++ b/core/delegation/delegate.go
@@ -2,7 +2,6 @@ package delegation
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/web3-storage/go-ucanto/core/dag/blockstore"
 	"github.com/web3-storage/go-ucanto/core/ipld/block"
@@ -20,7 +19,7 @@ type delegationConfig struct {
 	nbf uint64
 	nnc string
 	fct []ucan.FactBuilder
-	prf []Delegation
+	prf Proofs
 }
 
 // WithExpiration configures the expiration time in UTC seconds since Unix
@@ -61,7 +60,7 @@ func WithFacts(fct []ucan.FactBuilder) Option {
 // `Delegation` is not the resource owner / service provider, for the delegated
 // capabilities, the `proofs` must contain valid `Proof`s containing
 // delegations to the `issuer`.
-func WithProofs(prf []Delegation) Option {
+func WithProofs(prf Proofs) Option {
 	return func(cfg *delegationConfig) error {
 		cfg.prf = prf
 		return nil
@@ -79,28 +78,14 @@ func Delegate(issuer ucan.Signer, audience ucan.Principal, capabilities []ucan.C
 		}
 	}
 
-	var links []ucan.Link
 	bs, err := blockstore.NewBlockStore()
 	if err != nil {
 		return nil, err
 	}
 
-	for _, p := range cfg.prf {
-		links = append(links, p.Link())
-		blks := p.Blocks()
-		for {
-			b, err := blks.Next()
-			if err != nil {
-				if err == io.EOF {
-					break
-				}
-				return nil, fmt.Errorf("reading proof blocks: %s", err)
-			}
-			err = bs.Put(b)
-			if err != nil {
-				return nil, fmt.Errorf("putting proof block: %s", err)
-			}
-		}
+	links, err := cfg.prf.Encode(bs)
+	if err != nil {
+		return nil, err
 	}
 
 	data, err := ucan.Issue(

--- a/core/delegation/delegation.go
+++ b/core/delegation/delegation.go
@@ -22,7 +22,7 @@ import (
 // Delagation is a materialized view of a UCAN delegation, which can be encoded
 // into a UCAN token and used as proof for an invocation or further delegations.
 type Delegation interface {
-	ipld.IPLDView
+	ipld.View
 	// Link returns the IPLD link of the root block of the delegation.
 	Link() ucan.Link
 	// Archive writes the delegation to a Content Addressed aRchive (CAR).

--- a/core/delegation/proofs.go
+++ b/core/delegation/proofs.go
@@ -1,0 +1,60 @@
+package delegation
+
+import (
+	"github.com/web3-storage/go-ucanto/core/dag/blockstore"
+	"github.com/web3-storage/go-ucanto/core/ipld"
+	"github.com/web3-storage/go-ucanto/ucan"
+)
+
+type Proof struct {
+	delegation Delegation
+	link       ucan.Link
+}
+
+func (p Proof) Delegation() (Delegation, bool) {
+	return p.delegation, p.delegation != nil
+}
+
+func (p Proof) Link() ucan.Link {
+	if p.delegation != nil {
+		return p.delegation.Link()
+	}
+	return p.link
+}
+
+func FromDelegation(delegation Delegation) Proof {
+	return Proof{delegation, nil}
+}
+
+func FromLink(link ucan.Link) Proof {
+	return Proof{nil, link}
+}
+
+type Proofs []Proof
+
+func NewProofsView(links []ipld.Link, bs blockstore.BlockReader) Proofs {
+	proofs := make(Proofs, 0, len(links))
+	for _, link := range links {
+		if delegation, err := NewDelegationView(link, bs); err == nil {
+			proofs = append(proofs, FromDelegation(delegation))
+		} else {
+			proofs = append(proofs, FromLink(link))
+		}
+	}
+	return proofs
+}
+
+// Encode writes a set of proofs, some of which may be full delegations to a blockstore
+func (proofs Proofs) Encode(bs blockstore.BlockWriter) ([]ipld.Link, error) {
+	links := make([]ucan.Link, 0, len(proofs))
+	for _, p := range proofs {
+		links = append(links, p.Link())
+		if delegation, isDelegation := p.Delegation(); isDelegation {
+			err := blockstore.Encode(delegation, bs)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return links, nil
+}

--- a/core/invocation/invocation.go
+++ b/core/invocation/invocation.go
@@ -35,3 +35,34 @@ type IssuedInvocation interface {
 func Invoke(issuer ucan.Signer, audience ucan.Principal, capability ucan.Capability[ucan.CaveatBuilder], options ...delegation.Option) (IssuedInvocation, error) {
 	return delegation.Delegate(issuer, audience, []ucan.Capability[ucan.CaveatBuilder]{capability}, options...)
 }
+
+type Ran struct {
+	invocation Invocation
+	link       ucan.Link
+}
+
+func (r Ran) Invocation() (Invocation, bool) {
+	return r.invocation, r.invocation != nil
+}
+
+func (r Ran) Link() ucan.Link {
+	if r.invocation != nil {
+		return r.invocation.Link()
+	}
+	return r.link
+}
+
+func FromInvocation(invocation Invocation) Ran {
+	return Ran{invocation, nil}
+}
+
+func FromLink(link ucan.Link) Ran {
+	return Ran{nil, link}
+}
+
+func (r Ran) Encode(bs blockstore.BlockWriter) (ipld.Link, error) {
+	if invocation, ok := r.Invocation(); ok {
+		return r.Link(), blockstore.Encode(invocation, bs)
+	}
+	return r.Link(), nil
+}

--- a/core/ipld/lib.go
+++ b/core/ipld/lib.go
@@ -7,3 +7,4 @@ import (
 
 type Link = ipld.Link
 type Block = block.Block
+type Node = ipld.Node

--- a/core/ipld/view.go
+++ b/core/ipld/view.go
@@ -7,7 +7,7 @@ import (
 // View represents a materialized IPLD DAG View, which provides a generic
 // traversal API. It is useful for encoding (potentially partial) IPLD DAGs
 // into content archives (e.g. CARs).
-type IPLDView interface {
+type View interface {
 	// Root is the root block of the IPLD DAG this is the view of. This is the
 	// block from which all other blocks are linked directly or transitively.
 	Root() Block
@@ -20,4 +20,15 @@ type IPLDView interface {
 	// Iterator MUST include the root block otherwise it will lead encoders into
 	// omitting it when encoding the view into a CAR archive.
 	Blocks() iterable.Iterator[Block]
+}
+
+// ViewBuilder represents a materializable IPLD DAG View. It is a useful
+// abstraction that can be used to defer actual IPLD encoding.
+//
+// Note that represented DAG could be partial implying that some of the blocks
+// may not be included. This by design allowing a user to include whatever
+// blocks they want to include.
+type ViewBuilder[V View] interface {
+	// BuildIPLDView encodes all the blocks and creates a new IPLDView instance over them.
+	BuildIPLDView() V
 }

--- a/core/message/message.go
+++ b/core/message/message.go
@@ -2,7 +2,6 @@ package message
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/web3-storage/go-ucanto/core/dag/blockstore"
 	"github.com/web3-storage/go-ucanto/core/invocation"
@@ -12,6 +11,7 @@ import (
 	"github.com/web3-storage/go-ucanto/core/ipld/hash/sha256"
 	"github.com/web3-storage/go-ucanto/core/iterable"
 	mdm "github.com/web3-storage/go-ucanto/core/message/datamodel"
+	"github.com/web3-storage/go-ucanto/core/receipt"
 )
 
 type AgentMessage interface {
@@ -73,7 +73,7 @@ func (m *message) Get(link ipld.Link) (ipld.Link, bool) {
 	return rcpt, true
 }
 
-func Build(invocations []invocation.Invocation) (AgentMessage, error) {
+func Build(invocations []invocation.Invocation, receipts []receipt.UniversalReceipt) (AgentMessage, error) {
 	bs, err := blockstore.NewBlockStore()
 	if err != nil {
 		return nil, err
@@ -83,18 +83,27 @@ func Build(invocations []invocation.Invocation) (AgentMessage, error) {
 	for _, inv := range invocations {
 		ex = append(ex, inv.Link())
 
-		blks := inv.Blocks()
-		for {
-			b, err := blks.Next()
+		err := blockstore.Encode(inv, bs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var report *mdm.ReportModel
+	if len(receipts) > 0 {
+		report = &mdm.ReportModel{
+			Keys:   make([]string, 0, len(receipts)),
+			Values: make(map[string]ipld.Link, len(receipts)),
+		}
+		for _, receipt := range receipts {
+			err := blockstore.Encode(receipt, bs)
 			if err != nil {
-				if err == io.EOF {
-					break
-				}
-				return nil, fmt.Errorf("reading invocation blocks: %s", err)
+				return nil, err
 			}
-			err = bs.Put(b)
-			if err != nil {
-				return nil, fmt.Errorf("putting invocation block: %s", err)
+
+			key := receipt.Ran().Link().String()
+			if _, ok := report.Values[key]; !ok {
+				report.Values[key] = receipt.Root().Link()
 			}
 		}
 	}
@@ -102,6 +111,7 @@ func Build(invocations []invocation.Invocation) (AgentMessage, error) {
 	msg := mdm.AgentMessageModel{
 		UcantoMessage7: &mdm.DataModel{
 			Execute: ex,
+			Report:  report,
 		},
 	}
 

--- a/core/message/message.go
+++ b/core/message/message.go
@@ -15,7 +15,7 @@ import (
 )
 
 type AgentMessage interface {
-	ipld.IPLDView
+	ipld.View
 	// Invocations is a list of links to the root block of invocations than can
 	// be found in the message.
 	Invocations() []ipld.Link

--- a/core/receipt/datamodel/receipt.go
+++ b/core/receipt/datamodel/receipt.go
@@ -37,8 +37,8 @@ type MetaModel struct {
 }
 
 type ResultModel[O any, X any] struct {
-	Ok  O
-	Err X
+	Ok  *O
+	Err *X
 }
 
 // NewReceiptModelType creates a new schema.Type for a Receipt. You must

--- a/core/receipt/datamodel/receipt_test.go
+++ b/core/receipt/datamodel/receipt_test.go
@@ -39,10 +39,10 @@ func TestEncodeDecode(t *testing.T) {
 	}
 
 	l := cidlink.Link{Cid: cid.MustParse("bafkreiem4twkqzsq2aj4shbycd4yvoj2cx72vezicletlhi7dijjciqpui")}
-	r0 := rdm.ReceiptModel[*resultOk, *resultErr]{
-		Ocm: rdm.OutcomeModel[*resultOk, *resultErr]{
+	r0 := rdm.ReceiptModel[resultOk, resultErr]{
+		Ocm: rdm.OutcomeModel[resultOk, resultErr]{
 			Ran: l,
-			Out: rdm.ResultModel[*resultOk, *resultErr]{
+			Out: rdm.ResultModel[resultOk, resultErr]{
 				Ok: &resultOk{Status: "done"},
 			},
 		},
@@ -51,7 +51,7 @@ func TestEncodeDecode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("encoding receipt: %s", err)
 	}
-	r1 := rdm.ReceiptModel[*resultOk, *resultErr]{}
+	r1 := rdm.ReceiptModel[resultOk, resultErr]{}
 	err = block.Decode(b0, &r1, typ, cbor.Codec, sha256.Hasher)
 	if err != nil {
 		t.Fatalf("decoding receipt: %s", err)
@@ -63,10 +63,10 @@ func TestEncodeDecode(t *testing.T) {
 		t.Fatalf("status was not done")
 	}
 
-	r2 := rdm.ReceiptModel[*resultOk, *resultErr]{
-		Ocm: rdm.OutcomeModel[*resultOk, *resultErr]{
+	r2 := rdm.ReceiptModel[resultOk, resultErr]{
+		Ocm: rdm.OutcomeModel[resultOk, resultErr]{
 			Ran: l,
-			Out: rdm.ResultModel[*resultOk, *resultErr]{
+			Out: rdm.ResultModel[resultOk, resultErr]{
 				Err: &resultErr{Message: "boom"},
 			},
 		},
@@ -75,7 +75,7 @@ func TestEncodeDecode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("encoding receipt: %s", err)
 	}
-	r3 := rdm.ReceiptModel[*resultOk, *resultErr]{}
+	r3 := rdm.ReceiptModel[resultOk, resultErr]{}
 	err = block.Decode(b1, &r3, typ, cbor.Codec, sha256.Hasher)
 	if err != nil {
 		t.Fatalf("decoding receipt: %s", err)

--- a/core/result/datamodel/failure.go
+++ b/core/result/datamodel/failure.go
@@ -1,0 +1,42 @@
+package datamodel
+
+import (
+	// to use go:embed
+	_ "embed"
+	"fmt"
+	"sync"
+
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+//go:embed failure.ipldsch
+var failureSchema []byte
+
+// Failure is a generic failure
+type Failure struct {
+	Name    *string
+	Message string
+	Stack   *string
+}
+
+var (
+	once sync.Once
+	ts   *schema.TypeSystem
+	err  error
+)
+
+func mustLoadSchema() *schema.TypeSystem {
+	once.Do(func() {
+		ts, err = ipld.LoadSchemaBytes(failureSchema)
+	})
+	if err != nil {
+		panic(fmt.Errorf("failed to load IPLD schema: %s", err))
+	}
+	return ts
+}
+
+// returns the failure schematype
+func Type() schema.Type {
+	return mustLoadSchema().TypeByName("Failure")
+}

--- a/core/result/datamodel/failure.ipldsch
+++ b/core/result/datamodel/failure.ipldsch
@@ -1,0 +1,5 @@
+type Failure struct {
+  name optional String
+  message String
+  stack optional String
+}

--- a/core/result/result.go
+++ b/core/result/result.go
@@ -1,28 +1,116 @@
 package result
 
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/ipld/go-ipld-prime/node/bindnode"
+	"github.com/pkg/errors"
+	"github.com/web3-storage/go-ucanto/core/ipld"
+	"github.com/web3-storage/go-ucanto/core/result/datamodel"
+)
+
 // https://github.com/ucan-wg/invocation/#6-result
 type Result[O any, X any] interface {
-	Ok() O
-	Error() X
+	Ok() (O, bool)
+	Error() (X, bool)
 }
 
-// type result[O any, X any] struct {
-// 	ok  O
-// 	err X
-// }
+type UniversalResult Result[ipld.Node, ipld.Node]
 
-// func (r result[O, X]) Ok() O {
-// 	return r.ok
-// }
+type universalResult struct {
+	ok  *ipld.Node
+	err *ipld.Node
+}
 
-// func (r result[O, X]) Error() X {
-// 	return r.err
-// }
+func (ur universalResult) Ok() (ipld.Node, bool) {
+	if ur.ok != nil {
+		return *ur.ok, true
+	}
+	return nil, false
+}
 
-// func Ok[O any](value O) Result[O, any] {
-// 	return result[O, any]{value, nil}
-// }
+func (ur universalResult) Error() (ipld.Node, bool) {
+	if ur.err != nil {
+		return *ur.err, true
+	}
+	return nil, false
+}
 
-// func Error[X any](value X) Result[any, X] {
-// 	return result[any, X]{nil, value}
-// }
+func Ok(value ipld.Node) UniversalResult {
+	return universalResult{&value, nil}
+}
+
+func Error(err ipld.Node) UniversalResult {
+	return universalResult{nil, &err}
+}
+
+// Named is an error that you can read a name from
+type Named interface {
+	Name() string
+}
+
+// WithStackTrace is an error that you can read a stack trace from
+type WithStackTrace interface {
+	Stack() string
+}
+
+// IPLDConvertableError is an error with a custom method to convert to an IPLD Node
+type IPLDConvertableError interface {
+	error
+	ToIPLD() ipld.Node
+}
+
+type NamedWithStackTrace interface {
+	Named
+	WithStackTrace
+}
+
+type namedWithStackTrace struct {
+	name  string
+	stack errors.StackTrace
+}
+
+func (n namedWithStackTrace) Name() string {
+	return n.name
+}
+
+func (n namedWithStackTrace) Stack() string {
+	return fmt.Sprintf("%+v", n.stack)
+}
+
+func NamedWithCurrentStackTrace(name string) NamedWithStackTrace {
+	const depth = 32
+
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+
+	f := make(errors.StackTrace, n)
+	for i := 0; i < n; i++ {
+		f[i] = errors.Frame(pcs[i])
+	}
+
+	return namedWithStackTrace{name, f}
+}
+
+// Failure generates a Result from a golang error, using:
+//  1. a custom conversion to IPLD if present
+//  2. the golangs error message plus
+//     a. a name, if it is a named error
+//     b. a stack trace, if it has a stack trace
+func Failure(err error) UniversalResult {
+	if ipldConvertableError, ok := err.(IPLDConvertableError); ok {
+		return Error(ipldConvertableError.ToIPLD())
+	}
+
+	failure := datamodel.Failure{Message: err.Error()}
+	if named, ok := err.(Named); ok {
+		name := named.Name()
+		failure.Name = &name
+	}
+	if withStackTrace, ok := err.(WithStackTrace); ok {
+		stack := withStackTrace.Stack()
+		failure.Stack = &stack
+	}
+	return Error(bindnode.Wrap(&failure, datamodel.Type()))
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/multiformats/go-multibase v0.2.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/multiformats/go-varint v0.0.7
+	github.com/pkg/errors v0.9.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,9 @@ github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOEL
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polydawn/refmt v0.89.0 h1:ADJTApkvkeBZsN0tBTx8QjpD9JkmxbKp0cxfr9qszm4=


### PR DESCRIPTION
# Goals

Adds the ability to write receipts. This will be needed for the server.


# Implementation

I had to think through how the write side of receipts is going to work since we hadn't really addressed that. I ultimately decided for writing, it is much easier to avoid really specific receipts and just fall back on an Any type in the IPLD schema, which means the result just needs a datamodel.Node()

I also started to fill out the result model a bit for this Any type -- including some functionality mirroring the Failure class in js-ucanto.

One other item I added support for is partial proof chains -- i.e. receipts/invocations where most of the blocks are NOT contained entirely within the CAR file. js-ucanto seems to support this.  (though maybe not for invocations? Not sure)

Anyway, this was a fascinating exercise in learning about the ucanto library. The typing in the JS version is IMHO, wildly complicated and unveildy and the limitations of go types are quite useful in simplifying things, even if it's a bit verbose.

btw, the whole "how do we handle the result type" is really yet another case of this -- https://github.com/ipld/go-ipld-prime/issues/443 -- how to deserialize schema'd types with a possibly unknown schema somewhere in the tree (but that you might have some hints about). I also noticed we still have VERY poor support in IPLD prime for combining schema trees. What you really out to be able to do all the combination with schema.Type values rather than byte reads of the schema files, which is way ineffecient. I filed an issue here: https://github.com/ipld/go-ipld-prime/issues/568

I'm actually a good bit of the way through the validator package but wanted to try to ship vaguely incrementally so stopping here.