### PR TITLE
Add two value iterable for maps

### DIFF
--- a/core/iterable/iterable.go
+++ b/core/iterable/iterable.go
@@ -22,7 +22,7 @@ func NewIterator[T any](next func() (T, error)) Iterator[T] {
 	return &iterator[T]{next}
 }
 
-func From[T any](slice []T) Iterator[T] {
+func From[Slice ~[]T, T any](slice Slice) Iterator[T] {
 	i := 0
 	return NewIterator(func() (T, error) {
 		if i < len(slice) {

--- a/core/iterable/mapiterable.go
+++ b/core/iterable/mapiterable.go
@@ -1,0 +1,91 @@
+package iterable
+
+import "io"
+
+// Iterator2 returns two values with every call to Next().
+// The error will be set to io.EOF when the iterator is complete.
+type Iterator2[K any, V any] interface {
+	Next() (K, V, error)
+}
+
+type iterator2[K any, V any] struct {
+	next func() (K, V, error)
+}
+
+func (mit *iterator2[K, V]) Next() (K, V, error) {
+	return mit.next()
+}
+
+func NewIterator2[K any, V any](next func() (K, V, error)) Iterator2[K, V] {
+	return &iterator2[K, V]{next}
+}
+
+type mapEntry[K comparable, V any] struct {
+	k K
+	v V
+}
+
+func FromMap[Map ~map[K]V, K comparable, V any](m Map) Iterator2[K, V] {
+	entries := make([]mapEntry[K, V], 0, len(m))
+	for k, v := range m {
+		entries = append(entries, mapEntry[K, V]{k, v})
+	}
+	i := 0
+	return NewIterator2(func() (K, V, error) {
+		if i < len(entries) {
+			k := entries[i].k
+			v := entries[i].v
+			i++
+			return k, v, nil
+		}
+		var k K
+		var v V
+		return k, v, io.EOF
+	})
+}
+
+func CollectMap[K comparable, V any](mit Iterator2[K, V]) (map[K]V, error) {
+	items := make(map[K]V)
+	for {
+		k, v, err := mit.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		items[k] = v
+	}
+	return items, nil
+}
+
+func Concat2[K any, V any](iterators ...Iterator2[K, V]) Iterator2[K, V] {
+	if len(iterators) == 0 {
+		return NewIterator2(func() (K, V, error) {
+			var k K
+			var v V
+			return k, v, io.EOF
+		})
+	}
+
+	i := 0
+	iterator := iterators[i]
+	return NewIterator2(func() (K, V, error) {
+		for {
+			k, v, err := iterator.Next()
+			if err != nil {
+				if err == io.EOF {
+					i++
+					if i < len(iterators) {
+						iterator = iterators[i]
+						continue
+					}
+				}
+				var k K
+				var v V
+				return k, v, err
+			}
+			return k, v, nil
+		}
+	})
+}

--- a/core/iterable/mapiterable_test.go
+++ b/core/iterable/mapiterable_test.go
@@ -1,0 +1,114 @@
+package iterable_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/storacha-network/go-ucanto/core/iterable"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectMap(t *testing.T) {
+	someErr := errors.New("some error")
+	testCases := []struct {
+		name        string
+		iterator2   func() iterable.Iterator2[string, int]
+		expectedMap map[string]int
+		expectedErr error
+	}{
+		{
+			name: "converts successful iterator to expected map",
+			iterator2: func() iterable.Iterator2[string, int] {
+				count := 0
+				return iterable.NewIterator2(func() (string, int, error) {
+					defer func() {
+						count++
+					}()
+					switch count {
+					case 0:
+						return "apples", 7, nil
+					case 1:
+						return "oranges", 4, nil
+					case 2:
+						return "", 0, io.EOF
+					default:
+						return "", 0, fmt.Errorf("too many calls to iterator: %d", count+1)
+					}
+				})
+			},
+			expectedMap: map[string]int{"apples": 7, "oranges": 4},
+		},
+		{
+			name: "fails when iterator fails",
+			iterator2: func() iterable.Iterator2[string, int] {
+				count := 0
+				return iterable.NewIterator2(func() (string, int, error) {
+					defer func() {
+						count++
+					}()
+					switch count {
+					case 0:
+						return "apples", 7, nil
+					default:
+						return "", 0, fmt.Errorf("mistake iterating: %w", someErr)
+					}
+				})
+			},
+			expectedMap: nil,
+			expectedErr: someErr,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			resultMap, err := iterable.CollectMap(testCase.iterator2())
+			require.Equal(t, testCase.expectedMap, resultMap)
+			require.ErrorIs(t, err, testCase.expectedErr)
+		})
+	}
+}
+
+func TestFromMap(t *testing.T) {
+	verifyFromMap(t, "string -> int", map[string]int{"apples": 7, "oranges": 4})
+	verifyFromMap(t, "int -> bool", map[int]bool{7: true, 4: false, 3: true})
+	verifyFromMap(t, "any -> any", map[any]any{
+		7:         true,
+		4:         "apples",
+		"oranges": struct{ head string }{head: "bucket"},
+	})
+}
+
+func TestRoundtrip(t *testing.T) {
+	roundTrip(t, "string -> int", map[string]int{"apples": 7, "oranges": 4})
+	roundTrip(t, "int -> bool", map[int]bool{7: true, 4: false, 3: true})
+	roundTrip(t, "any -> any", map[any]any{
+		7:         true,
+		4:         "apples",
+		"oranges": struct{ head string }{head: "bucket"},
+	})
+}
+
+func verifyFromMap[K comparable, V any](t *testing.T, testCase string, inputMap map[K]V) {
+	t.Run(testCase, func(t *testing.T) {
+		iterator := iterable.FromMap(inputMap)
+		outputMap := make(map[K]V, len(inputMap))
+		for {
+			k, v, err := iterator.Next()
+			if err != nil {
+				require.ErrorIs(t, err, io.EOF)
+				require.Equal(t, inputMap, outputMap)
+				return
+			}
+			outputMap[k] = v
+		}
+	})
+}
+
+func roundTrip[K comparable, V any](t *testing.T, testCase string, inputMap map[K]V) {
+	t.Run(testCase, func(t *testing.T) {
+		outputMap, err := iterable.CollectMap(iterable.FromMap(inputMap))
+		require.NoError(t, err)
+		require.Equal(t, inputMap, outputMap)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,11 @@ require (
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/multiformats/go-varint v0.0.7
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.8.4
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -43,6 +45,7 @@ require (
 	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polydawn/refmt v0.89.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/whyrusleeping/cbor-gen v0.0.0-20230818171029-f91ae536ca25 // indirect
@@ -55,5 +58,6 @@ require (
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.1.7 // indirect
 )


### PR DESCRIPTION
# Goals

Might be useful to iterate maps as well

# Implementation

- Adds two value iterator with functions to go to and from maps
- Note that maps require comparable for keys, but there might be cases where you still want an iterator, so the iterator constraint is any/any while the map conversion functions are comparable/any
- Minor type improvement on original iterable

# For Discussion

- We should really get rid of these when go 1.23 comes out. It has all these functions built in
- What's the deal with ucanto being a bucket for various forms of language and library DX improvements? IOW, we have our own little adds to IPLD, CAR, go lang / js itself all in a library for UCANs. It seems a little odd and I wonder if it makes sense to break it out as seperate packages? I guess on JS side maybe it is. Like I said just seems odd.