### PR TITLE
Optimizations for rebind

### DIFF
--- a/core/ipld/rebind.go
+++ b/core/ipld/rebind.go
@@ -2,8 +2,6 @@ package ipld
 
 import (
 	"errors"
-	"fmt"
-	"reflect"
 
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/node/bindnode"
@@ -11,7 +9,7 @@ import (
 )
 
 // Rebind takes a Node and binds it to the Go type according to the passed schema.
-func Rebind(nd datamodel.Node, ptrVal any, typ schema.Type) (rnd datamodel.Node, err error) {
+func Rebind[T any](nd datamodel.Node, typ schema.Type) (ptrVal T, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if asStr, ok := r.(string); ok {
@@ -24,177 +22,14 @@ func Rebind(nd datamodel.Node, ptrVal any, typ schema.Type) (rnd datamodel.Node,
 		}
 	}()
 
-	err = verifyCompatibility(nd, typ)
+	var nilbind T
+	np := bindnode.Prototype(&nilbind, typ)
+	nb := np.Representation().NewBuilder()
+	err = nb.AssignNode(nd)
 	if err != nil {
 		return
 	}
-
-	np := bindnode.Prototype(ptrVal, typ)
-	nb := np.Representation().NewBuilder()
-	nb.AssignNode(nd)
-	nd = nb.Build()
-
-	// Code and comments below are from UnmarshalStreaming...
-	// https://github.com/ipld/go-ipld-prime/blob/36adac0f53c70d7fab5131c4295054463b7b6cb3/codecHelpers.go#L161-L168
-
-	// ... but our approach above allocated new memory, and we have to copy it back out.
-	// In the future, the bindnode API could be improved to make this easier.
-	if !reflect.ValueOf(ptrVal).IsNil() {
-		reflect.ValueOf(ptrVal).Elem().Set(reflect.ValueOf(bindnode.Unwrap(nd)).Elem())
-	}
-	// ... and we also have to re-bind a new node to the 'bind' value,
-	// because probably the user will be surprised if mutating 'bind' doesn't affect the Node later.
-	rnd = bindnode.Wrap(ptrVal, typ)
+	rnd := nb.Build()
+	ptrVal = *bindnode.Unwrap(rnd).(*T)
 	return
-}
-
-// verifyCompatibility checks the node tree matches the schema.
-func verifyCompatibility(node datamodel.Node, schemaType schema.Type) error {
-	doError := func(format string, args ...interface{}) error {
-		errFormat := "rebind: schema type %s is not compatible with node type %s"
-		errArgs := []interface{}{schemaType.Name(), node.Kind().String()}
-		if format != "" {
-			errFormat += ": " + format
-		}
-		errArgs = append(errArgs, args...)
-		return fmt.Errorf(errFormat, errArgs...)
-	}
-	switch schemaType := schemaType.(type) {
-	case *schema.TypeBool:
-		if node.Kind() != datamodel.Kind_Bool {
-			return doError("kind mismatch; need boolean")
-		}
-	case *schema.TypeInt:
-		if node.Kind() != datamodel.Kind_Int {
-			return doError("kind mismatch; need integer")
-		}
-	case *schema.TypeFloat:
-		if node.Kind() != datamodel.Kind_Float {
-			return doError("kind mismatch; need float")
-		}
-	case *schema.TypeString:
-		if node.Kind() != datamodel.Kind_String {
-			return doError("kind mismatch; need string")
-		}
-	case *schema.TypeBytes:
-		if node.Kind() != datamodel.Kind_Bytes {
-			return doError("kind mismatch; need bytes")
-		}
-	case *schema.TypeEnum:
-		if _, ok := schemaType.RepresentationStrategy().(schema.EnumRepresentation_Int); ok {
-			if node.Kind() != datamodel.Kind_Int {
-				return doError("kind mismatch; need integer enum")
-			}
-		} else if node.Kind() != datamodel.Kind_String {
-			return doError("kind mismatch; need string enum")
-		}
-	case *schema.TypeList:
-		if node.Kind() != datamodel.Kind_List {
-			return doError("kind mismatch; need list")
-		}
-
-		it := node.ListIterator()
-		for {
-			if it.Done() {
-				break
-			}
-			_, nd, err := it.Next()
-			if err != nil {
-				return err
-			}
-			if nd.Kind() == datamodel.Kind_Null && schemaType.ValueIsNullable() {
-				continue
-			}
-
-			err = verifyCompatibility(nd, schemaType.ValueType())
-			if err != nil {
-				return err
-			}
-		}
-	case *schema.TypeMap:
-		if node.Kind() != datamodel.Kind_Map {
-			return doError("kind mismatch; need map")
-		}
-
-		it := node.MapIterator()
-		for {
-			if it.Done() {
-				break
-			}
-			k, v, err := it.Next()
-			if err != nil {
-				return err
-			}
-
-			err = verifyCompatibility(k, schemaType.KeyType())
-			if err != nil {
-				return err
-			}
-
-			if v.Kind() == datamodel.Kind_Null && schemaType.ValueIsNullable() {
-				continue
-			}
-			err = verifyCompatibility(v, schemaType.ValueType())
-			if err != nil {
-				return err
-			}
-		}
-	case *schema.TypeStruct:
-		if node.Kind() != datamodel.Kind_Map {
-			return doError("kind mismatch; need struct")
-		}
-
-		for _, schemaField := range schemaType.Fields() {
-			schemaType := schemaField.Type()
-			vnode, err := node.LookupByString(schemaField.Name())
-			if err != nil {
-				return err
-			}
-
-			switch {
-			case schemaField.IsOptional() && schemaField.IsNullable():
-				if vnode == nil || vnode.Kind() == datamodel.Kind_Null {
-					continue
-				}
-			case schemaField.IsOptional():
-				if vnode == nil {
-					continue
-				}
-				if vnode.Kind() == datamodel.Kind_Null {
-					return doError("optional field is not nullable")
-				}
-			case schemaField.IsNullable():
-				if vnode == nil {
-					return doError("nullable field is not optional")
-				}
-				if vnode.Kind() == datamodel.Kind_Null {
-					continue
-				}
-			}
-			err = verifyCompatibility(vnode, schemaType)
-			if err != nil {
-				return err
-			}
-		}
-	case *schema.TypeUnion:
-		schemaMembers := schemaType.Members()
-		var err error
-		for _, schemaType := range schemaMembers {
-			err = verifyCompatibility(node, schemaType)
-			if err == nil {
-				break
-			}
-		}
-		if err != nil {
-			return err
-		}
-	case *schema.TypeLink:
-		if node.Kind() != datamodel.Kind_Link {
-			return doError("kind mismatch; need link")
-		}
-	case *schema.TypeAny:
-	default:
-		return doError(fmt.Sprintf("unexpected schema type: %T", schemaType))
-	}
-	return nil
 }

--- a/core/ipld/rebind_test.go
+++ b/core/ipld/rebind_test.go
@@ -109,8 +109,7 @@ func TestRebind(t *testing.T) {
 		t.Fatalf("decoding base: %s", err)
 	}
 
-	var sub Target
-	_, err = Rebind(bind.Value, &sub, ttyp)
+	sub, err := Rebind[Target](bind.Value, ttyp)
 	if err != nil {
 		t.Fatalf("binding subtype: %s", err)
 	}
@@ -171,8 +170,7 @@ func TestRebindNonCompatibleStruct(t *testing.T) {
 		t.Fatalf("decoding base: %s", err)
 	}
 
-	var sub TargetIncompatible
-	_, err = Rebind(bind.Value, &sub, ttyp)
+	_, err = Rebind[TargetIncompatible](bind.Value, ttyp)
 	if err == nil {
 		t.Fatalf("expected error rebinding")
 	}
@@ -225,8 +223,7 @@ func TestRebindNonCompatibleSchema(t *testing.T) {
 		t.Fatalf("decoding base: %s", err)
 	}
 
-	var sub Target
-	_, err = Rebind(bind.Value, &sub, ttyp)
+	_, err = Rebind[Target](bind.Value, ttyp)
 	if err == nil {
 		t.Fatalf("expected error rebinding")
 	}

--- a/core/schema/struct.go
+++ b/core/schema/struct.go
@@ -1,16 +1,13 @@
 package schema
 
 import (
-	"reflect"
-
 	"github.com/ipld/go-ipld-prime/schema"
 	"github.com/storacha-network/go-ucanto/core/ipld"
 	"github.com/storacha-network/go-ucanto/core/result"
 )
 
 type strukt[T any] struct {
-	bind T
-	typ  schema.Type
+	typ schema.Type
 }
 
 func (s *strukt[T]) Read(input any) result.Result[T, result.Failure] {
@@ -19,12 +16,7 @@ func (s *strukt[T]) Read(input any) result.Result[T, result.Failure] {
 		return result.Error[T](NewSchemaError("unexpected input: not an IPLD node"))
 	}
 
-	var nilbind T
-	bindtyp := reflect.TypeOf(nilbind).Elem()
-	bindptr := reflect.New(bindtyp)
-	bind := bindptr.Interface().(T)
-
-	_, err := ipld.Rebind(node, bind, s.typ)
+	bind, err := ipld.Rebind[T](node, s.typ)
 	if err != nil {
 		return result.Error[T](NewSchemaError(err.Error()))
 	}
@@ -33,6 +25,5 @@ func (s *strukt[T]) Read(input any) result.Result[T, result.Failure] {
 }
 
 func Struct[T any](typ schema.Type) Reader[any, T] {
-	var bind T
-	return &strukt[T]{bind: bind, typ: typ}
+	return &strukt[T]{typ: typ}
 }

--- a/core/schema/struct_test.go
+++ b/core/schema/struct_test.go
@@ -31,8 +31,8 @@ func TestReadStruct(t *testing.T) {
 		ma.Finish()
 		nd := nb.Build()
 
-		res := Struct[*TestStruct](ts.TypeByName("TestStruct")).Read(nd)
-		result.MatchResultR0(res, func(ok *TestStruct) {
+		res := Struct[TestStruct](ts.TypeByName("TestStruct")).Read(nd)
+		result.MatchResultR0(res, func(ok TestStruct) {
 			fmt.Printf("%+v\n", ok)
 			require.Equal(t, ok.Name, "foo")
 		}, func(err result.Failure) {


### PR DESCRIPTION
# Goals

- create a much simpler generic interface for rebind and simplify body as well

# Implementation

- remove copy/paste of bindnode.verifycompatibilty -- the proper way to do this is to check the err value on nodebuilder.AssignNode -- this operation will fail is the node structure is not compatible
- remove the additional copy paste from unmarshal streaming. All the fancy reflection basically to extract the copy of the struct built with prototype.NewBuilder and assign it to the pointer value for passed to the function. The simple fix is just lose the pointer value passed, and instead return the new copy. This didn't used to be possible cause of lack of generics, but you can do it now pretty easy.
- modify the Struct code to use the new version of rebind.
- also: the struct code contained a hidden assumption, which is that if you didn't pass a generic type that was a pointer, it would fail. The new version of Rebind properly handles pointer and non-pointer types which then propagates up to handling in Struct

# For discussion

I notice that you're keen to use pointer receivers for all your structs, and also to pass pointers to structs around. I have some views about this:

1. If you're dealing with an immutable value, which I expect something like say the Caveats on a UCAN Invocation to be, generally, I don't use pointer receivers -- it makes it clear that none of your methods modify the internal structure of the struct. I tend to use pointer receivers for structs that implement a service with internal state where the methods modify the internal state. There's some vague analogy here with the diffenence between stateful and stateless components in React.

2. Generally, I don't pass around pointers around unless I have to. Now, depending on how long you've been programming, you might have learned somewhere that passing big structs as values around means too much memory copying. generally, this isn't all that true with modern memory architectures. The copy is often quite fast if it happens in cache layers.

3. Which brings me to the real big plus one of passing around values: escape analysis. This article has a decent overview of escape analysis: https://medium.com/@trinad536/escape-analysis-in-golang-fc81b78f3550 . Essentially, when you compile a function the compiler has to decide whether to allocate the variables on the stack or the heap. The stack is generally much faster cause there's no garbage collection. (deallocation happens when the function is done) By and large, the magic words to not allocate on heap is don't pass back pointers except when you need to.