### PR TITLE
Car offsets

### DIFF
--- a/core/car/car_test.go
+++ b/core/car/car_test.go
@@ -47,7 +47,7 @@ func TestDecodeCAR(t *testing.T) {
 		t.Fatalf("unexpected root: %s, expected: %s", roots[0], fixtures[0].root)
 	}
 
-	var blks []ipld.Block
+	var blks []CarBlock
 	for {
 		b, err := blocks.Next()
 		if err != nil {
@@ -56,7 +56,11 @@ func TestDecodeCAR(t *testing.T) {
 			}
 			t.Fatalf("reading blocks: %s", err)
 		}
-		blks = append(blks, b)
+		cb, ok := b.(CarBlock)
+		if !ok {
+			t.Fatalf("did not return a CarBlock")
+		}
+		blks = append(blks, cb)
 	}
 
 	if len(blks) != len(fixtures[0].blocks) {
@@ -66,6 +70,22 @@ func TestDecodeCAR(t *testing.T) {
 		if b.String() != blks[i].Link().String() {
 			t.Fatalf("unexpected block: %s, expected: %s", b, blks[i].Link())
 		}
+		// verify offset and length can be used to directly read the block in the CAR file
+		file.Seek(int64(blks[i].Offset()), io.SeekStart)
+		data := make([]byte, blks[i].Length())
+		_, err := file.Read(data)
+		if err != nil {
+			t.Fatalf("error reading block from raw file")
+		}
+		hashed, err := blks[i].Link().(cidlink.Link).Cid.Prefix().Sum(data)
+		if err != nil {
+			t.Fatalf("error hashing block from raw file")
+		}
+
+		if hashed.String() != blks[i].Link().String() {
+			t.Fatalf("raw read from offset block: %s, expected: %s", hashed, blks[i].Link())
+		}
+
 	}
 }
 

--- a/core/iterable/iterable.go
+++ b/core/iterable/iterable.go
@@ -50,6 +50,17 @@ func Collect[T any](it Iterator[T]) ([]T, error) {
 	return items, nil
 }
 
+func Map[T, U any](it Iterator[T], mapFn func(T) U) Iterator[U] {
+	return NewIterator(func() (U, error) {
+		t, err := it.Next()
+		if err != nil {
+			var undef U
+			return undef, err
+		}
+		return mapFn(t), nil
+	})
+}
+
 func Concat[T any](iterators ...Iterator[T]) Iterator[T] {
 	if len(iterators) == 0 {
 		return From([]T{})


### PR DESCRIPTION
# Goals

To feature complete blob index module in indexer-service, we need offset and length for each block when reading from a car, so that we can generate sharded dag index.

# Implementation

- Adds a small bit of CAR offfset math under the hood so that we can get block offsets and lengths
- Adds a tests that verifies these can be used to read exact blocks out of a CAR file
- Adds a small utility function to convert one Iterator to another (i.e. make an interator where each element is wrapped)